### PR TITLE
fix: Double "@" on profile page

### DIFF
--- a/src/components/shared/TxnProfile.tsx
+++ b/src/components/shared/TxnProfile.tsx
@@ -27,7 +27,7 @@ const TxnProfile: FC<TxnProfileProps> = ({ profile }) => {
                 {profile.metadata?.displayName ?? formatAddress(profile.ownedBy.address)}
               </h1>
               <h3 className="text-sm font-medium opacity-60">
-                @{profile.handle?.suggestedFormatted.localName || profile.id}
+                {profile.handle?.suggestedFormatted.localName || profile.id}
               </h3>
               <p className="mt-3 text-sm font-medium opacity-60">{profile.metadata?.bio ?? ''}</p>
             </div>


### PR DESCRIPTION
I found two "@" displayed on the profile page, and this PR is used to fix this issue.

![image](https://github.com/lens-protocol/momoka-explorer/assets/67402215/3607dc7f-19df-496e-acef-e1f0eb82a791)